### PR TITLE
Upgrade neo4j-driver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angular2-in-memory-web-api": "0.0.18",
     "bootstrap": "^3.3.6",
 	
-	"neo4j-driver": "1.0.4"
+	"neo4j-driver": "1.3.0"
   },
   "devDependencies": {
     "concurrently": "^2.2.0",


### PR DESCRIPTION
To fix clock counter not being visible with neo4j-driver imported.